### PR TITLE
Add Chrome extension to capture and save products from greetbuy.com (Manifest V3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# Greetbuy Product Saver (Chrome Extension)
+
+Tiện ích Chrome giúp bạn lưu thông tin sản phẩm từ `greetbuy.com` về máy cục bộ (Chrome Storage Local).
+
+## Tính năng
+
+- Lưu thông tin sản phẩm tại trang `https://www.greetbuy.com/goods/*`.
+- Lưu dữ liệu cục bộ trên máy đã cài tiện ích.
+- Danh sách sản phẩm đã lưu hiển thị ngay trong popup.
+- Mỗi sản phẩm có:
+  - Ảnh đại diện
+  - Tên sản phẩm
+  - Giá (nếu lấy được)
+  - Nút mở trang chi tiết trong extension
+  - Nút mở lại trang gốc greetbuy
+
+## Cài đặt thủ công
+
+1. Mở `chrome://extensions`.
+2. Bật **Developer mode**.
+3. Chọn **Load unpacked**.
+4. Chọn thư mục dự án này.
+
+## Cách dùng
+
+1. Mở trang sản phẩm, ví dụ:  
+   `https://www.greetbuy.com/goods/taobao?id=920797232015`
+2. Bấm icon extension → **Lưu sản phẩm hiện tại**.
+3. Sản phẩm được lưu vào bộ nhớ local của Chrome trên máy của bạn.
+4. Từ popup, bấm **Mở chi tiết** để xem thông tin đã lưu hoặc **Mở nguồn** để quay lại trang gốc.
+
+## Ghi chú
+
+- Do mỗi website có cấu trúc HTML khác nhau theo thời điểm, extension sẽ cố gắng lấy dữ liệu theo nhiều selector phổ biến và có thể chưa đầy đủ 100% mọi trường hợp.
+- Dữ liệu không đồng bộ lên server, chỉ lưu local ở trình duyệt/máy cài tiện ích.

--- a/background.js
+++ b/background.js
@@ -1,0 +1,3 @@
+chrome.runtime.onInstalled.addListener(() => {
+  console.log('Greetbuy Product Saver installed');
+});

--- a/content-script.js
+++ b/content-script.js
@@ -1,0 +1,109 @@
+(() => {
+  const text = (el) => (el?.textContent || "").trim();
+
+  function getMeta(...selectors) {
+    for (const selector of selectors) {
+      const el = document.querySelector(selector);
+      if (!el) continue;
+      const value = el.getAttribute("content") || el.getAttribute("value") || text(el);
+      if (value) return value.trim();
+    }
+    return "";
+  }
+
+  function collectImages() {
+    const candidates = [
+      ...document.querySelectorAll('img[src]'),
+      ...document.querySelectorAll('[style*="background-image"]')
+    ];
+
+    const urls = new Set();
+    for (const node of candidates) {
+      if (node.tagName === 'IMG') {
+        const src = node.currentSrc || node.src;
+        if (src) urls.add(src);
+      } else {
+        const style = getComputedStyle(node).backgroundImage;
+        const match = style.match(/url\(["']?(.*?)["']?\)/i);
+        if (match?.[1]) urls.add(match[1]);
+      }
+    }
+
+    return [...urls].filter((url) => /^https?:\/\//i.test(url));
+  }
+
+  function collectJsonLd() {
+    const scripts = [...document.querySelectorAll('script[type="application/ld+json"]')];
+    const parsed = [];
+    for (const script of scripts) {
+      try {
+        parsed.push(JSON.parse(script.textContent));
+      } catch {
+        // ignore invalid json-ld
+      }
+    }
+    return parsed;
+  }
+
+  function collectSpecs() {
+    const map = {};
+    const rows = document.querySelectorAll('table tr, .specs tr, .detail tr, .attr tr, .attributes tr');
+    rows.forEach((row) => {
+      const cells = row.querySelectorAll('th,td');
+      if (cells.length >= 2) {
+        const key = text(cells[0]);
+        const value = text(cells[1]);
+        if (key && value) map[key] = value;
+      }
+    });
+    return map;
+  }
+
+  function collectProductData() {
+    const title =
+      text(document.querySelector('h1')) ||
+      getMeta('meta[property="og:title"]', 'meta[name="title"]') ||
+      document.title;
+
+    const description =
+      getMeta('meta[property="og:description"]', 'meta[name="description"]') ||
+      text(document.querySelector('.desc, .description, [class*="desc"]'));
+
+    const priceCandidates = [
+      ...document.querySelectorAll('[class*="price" i], .price, .goods-price, [data-price]')
+    ]
+      .map((el) => text(el))
+      .filter(Boolean);
+
+    const images = collectImages();
+    const specs = collectSpecs();
+
+    return {
+      sourceUrl: location.href,
+      sourceHost: location.host,
+      title,
+      description,
+      priceText: priceCandidates[0] || "",
+      priceCandidates,
+      images,
+      mainImage: images[0] || getMeta('meta[property="og:image"]'),
+      specs,
+      htmlSnapshot: document.documentElement.outerHTML,
+      jsonLd: collectJsonLd(),
+      capturedAt: new Date().toISOString()
+    };
+  }
+
+  chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+    if (message?.type !== 'GB_CAPTURE_PRODUCT') return;
+
+    try {
+      const data = collectProductData();
+      sendResponse({ ok: true, data });
+    } catch (error) {
+      sendResponse({ ok: false, error: error?.message || 'Không thể đọc dữ liệu sản phẩm.' });
+    }
+
+    return true;
+  });
+})();

--- a/detail.css
+++ b/detail.css
@@ -1,0 +1,70 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background: #f7f8fc;
+  color: #202124;
+}
+
+#app {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+.card {
+  background: #fff;
+  border: 1px solid #e5e8f0;
+  border-radius: 10px;
+  padding: 16px;
+}
+
+.header {
+  display: grid;
+  grid-template-columns: 180px 1fr;
+  gap: 16px;
+}
+
+.header img {
+  width: 100%;
+  border-radius: 10px;
+  object-fit: cover;
+  background: #f0f2f7;
+}
+
+h1 {
+  margin: 0 0 10px;
+  font-size: 24px;
+}
+
+.price {
+  color: #d93025;
+  font-weight: 700;
+}
+
+.actions {
+  margin-top: 12px;
+  display: flex;
+  gap: 8px;
+}
+
+button {
+  border: none;
+  background: #1a73e8;
+  color: #fff;
+  border-radius: 8px;
+  padding: 10px 12px;
+  cursor: pointer;
+}
+
+section {
+  margin-top: 16px;
+}
+
+pre {
+  background: #111827;
+  color: #e5e7eb;
+  padding: 12px;
+  border-radius: 8px;
+  overflow: auto;
+  font-size: 12px;
+}

--- a/detail.html
+++ b/detail.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="vi">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Chi tiết sản phẩm đã lưu</title>
+    <link rel="stylesheet" href="detail.css" />
+  </head>
+  <body>
+    <main id="app"></main>
+    <script src="detail.js"></script>
+  </body>
+</html>

--- a/detail.js
+++ b/detail.js
@@ -1,0 +1,64 @@
+const PRODUCT_KEY = 'gb_saved_products';
+
+function getIdFromQuery() {
+  const params = new URLSearchParams(location.search);
+  return params.get('id');
+}
+
+async function loadProducts() {
+  const data = await chrome.storage.local.get(PRODUCT_KEY);
+  return data[PRODUCT_KEY] || [];
+}
+
+function escapeHtml(str = '') {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+async function render() {
+  const app = document.getElementById('app');
+  const id = getIdFromQuery();
+  const products = await loadProducts();
+  const product = products.find((p) => p.id === id);
+
+  if (!product) {
+    app.innerHTML = '<p>Không tìm thấy sản phẩm đã lưu.</p>';
+    return;
+  }
+
+  const specsText = Object.keys(product.specs || {}).length
+    ? JSON.stringify(product.specs, null, 2)
+    : 'Không có thông số.';
+
+  app.innerHTML = `
+    <article class="card">
+      <div class="header">
+        <img src="${escapeHtml(product.mainImage || '')}" alt="${escapeHtml(product.title || '')}" />
+        <div>
+          <h1>${escapeHtml(product.title || '(Không có tiêu đề)')}</h1>
+          <p class="price">${escapeHtml(product.priceText || 'Chưa có giá')}</p>
+          <p>${escapeHtml(product.description || '')}</p>
+          <p><b>Nguồn:</b> ${escapeHtml(product.sourceUrl)}</p>
+          <div class="actions">
+            <button id="openSource">Mở trang gốc greetbuy.com</button>
+          </div>
+        </div>
+      </div>
+
+      <section>
+        <h2>Thông số thu thập được</h2>
+        <pre>${escapeHtml(specsText)}</pre>
+      </section>
+    </article>
+  `;
+
+  document.getElementById('openSource')?.addEventListener('click', () => {
+    chrome.tabs.create({ url: product.sourceUrl });
+  });
+}
+
+render();

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,22 @@
+{
+  "manifest_version": 3,
+  "name": "Greetbuy Product Saver",
+  "version": "1.0.0",
+  "description": "Lưu thông tin sản phẩm từ greetbuy.com vào bộ nhớ cục bộ của Chrome.",
+  "permissions": ["storage", "activeTab", "scripting", "tabs"],
+  "host_permissions": ["https://www.greetbuy.com/*"],
+  "action": {
+    "default_title": "Greetbuy Product Saver",
+    "default_popup": "popup.html"
+  },
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://www.greetbuy.com/goods/*"],
+      "js": ["content-script.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/popup.css
+++ b/popup.css
@@ -1,0 +1,100 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  width: 360px;
+  background: #f8f9fb;
+}
+
+.container {
+  padding: 12px;
+}
+
+h1 {
+  margin: 0 0 10px;
+  font-size: 16px;
+}
+
+h2 {
+  margin: 14px 0 8px;
+  font-size: 14px;
+}
+
+button {
+  border: none;
+  border-radius: 8px;
+  background: #1a73e8;
+  color: #fff;
+  padding: 10px 12px;
+  cursor: pointer;
+  width: 100%;
+}
+
+#status {
+  min-height: 20px;
+  font-size: 12px;
+  color: #333;
+  margin: 8px 0;
+}
+
+.products {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 360px;
+  overflow: auto;
+}
+
+.product {
+  display: grid;
+  grid-template-columns: 52px 1fr;
+  gap: 8px;
+  align-items: center;
+  background: #fff;
+  border-radius: 8px;
+  border: 1px solid #e6e8ef;
+  padding: 8px;
+}
+
+.product img {
+  width: 52px;
+  height: 52px;
+  object-fit: cover;
+  border-radius: 6px;
+  background: #f1f2f5;
+}
+
+.meta {
+  min-width: 0;
+}
+
+.title {
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.price {
+  font-size: 12px;
+  color: #d93025;
+}
+
+.actions {
+  margin-top: 4px;
+  display: flex;
+  gap: 6px;
+}
+
+.actions button {
+  width: auto;
+  font-size: 11px;
+  padding: 5px 8px;
+  border-radius: 6px;
+  background: #5f6368;
+}
+
+.empty {
+  font-size: 12px;
+  color: #666;
+}

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="vi">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Greetbuy Saver</title>
+    <link rel="stylesheet" href="popup.css" />
+  </head>
+  <body>
+    <main class="container">
+      <h1>Greetbuy Product Saver</h1>
+      <button id="saveCurrent">Lưu sản phẩm hiện tại</button>
+      <p id="status"></p>
+      <h2>Sản phẩm đã lưu</h2>
+      <div id="products" class="products"></div>
+    </main>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,126 @@
+const PRODUCT_KEY = 'gb_saved_products';
+
+const statusEl = document.getElementById('status');
+const productsEl = document.getElementById('products');
+const saveBtn = document.getElementById('saveCurrent');
+
+function setStatus(text, isError = false) {
+  statusEl.textContent = text;
+  statusEl.style.color = isError ? '#d93025' : '#188038';
+}
+
+async function getSavedProducts() {
+  const data = await chrome.storage.local.get(PRODUCT_KEY);
+  return data[PRODUCT_KEY] || [];
+}
+
+async function setSavedProducts(products) {
+  await chrome.storage.local.set({ [PRODUCT_KEY]: products });
+}
+
+function createProductId(url) {
+  const base = `${url}|${Date.now()}|${Math.random().toString(36).slice(2)}`;
+  return btoa(unescape(encodeURIComponent(base))).replace(/=/g, '');
+}
+
+function formatDate(isoDate) {
+  try {
+    return new Date(isoDate).toLocaleString('vi-VN');
+  } catch {
+    return isoDate;
+  }
+}
+
+async function renderProducts() {
+  const products = await getSavedProducts();
+  productsEl.innerHTML = '';
+
+  if (!products.length) {
+    productsEl.innerHTML = '<p class="empty">Chưa có sản phẩm nào được lưu.</p>';
+    return;
+  }
+
+  for (const product of products) {
+    const item = document.createElement('article');
+    item.className = 'product';
+
+    const image = document.createElement('img');
+    image.src = product.mainImage || '';
+    image.alt = product.title || 'Ảnh sản phẩm';
+
+    const meta = document.createElement('div');
+    meta.className = 'meta';
+
+    const title = document.createElement('div');
+    title.className = 'title';
+    title.textContent = product.title || '(Không có tiêu đề)';
+
+    const price = document.createElement('div');
+    price.className = 'price';
+    price.textContent = product.priceText || 'Chưa có giá';
+
+    const savedAt = document.createElement('div');
+    savedAt.style.fontSize = '11px';
+    savedAt.style.color = '#666';
+    savedAt.textContent = `Lưu lúc: ${formatDate(product.savedAt)}`;
+
+    const actions = document.createElement('div');
+    actions.className = 'actions';
+
+    const openDetailBtn = document.createElement('button');
+    openDetailBtn.textContent = 'Mở chi tiết';
+    openDetailBtn.addEventListener('click', () => {
+      const url = chrome.runtime.getURL(`detail.html?id=${encodeURIComponent(product.id)}`);
+      chrome.tabs.create({ url });
+    });
+
+    const openSourceBtn = document.createElement('button');
+    openSourceBtn.textContent = 'Mở nguồn';
+    openSourceBtn.addEventListener('click', () => {
+      chrome.tabs.create({ url: product.sourceUrl });
+    });
+
+    actions.append(openDetailBtn, openSourceBtn);
+    meta.append(title, price, savedAt, actions);
+    item.append(image, meta);
+
+    productsEl.appendChild(item);
+  }
+}
+
+async function saveCurrentProduct() {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+
+  if (!tab?.id || !tab.url?.includes('greetbuy.com/goods/')) {
+    setStatus('Hãy mở một trang sản phẩm greetbuy.com trước.', true);
+    return;
+  }
+
+  const response = await chrome.tabs.sendMessage(tab.id, { type: 'GB_CAPTURE_PRODUCT' });
+  if (!response?.ok) {
+    setStatus(response?.error || 'Không lấy được dữ liệu từ trang.', true);
+    return;
+  }
+
+  const product = response.data;
+  const savedProducts = await getSavedProducts();
+
+  const id = createProductId(product.sourceUrl);
+  savedProducts.unshift({
+    id,
+    ...product,
+    savedAt: new Date().toISOString()
+  });
+
+  await setSavedProducts(savedProducts);
+  setStatus('Đã lưu sản phẩm thành công.');
+  await renderProducts();
+}
+
+saveBtn.addEventListener('click', () => {
+  saveCurrentProduct().catch((error) => {
+    setStatus(error?.message || 'Có lỗi xảy ra khi lưu sản phẩm.', true);
+  });
+});
+
+renderProducts();


### PR DESCRIPTION
### Motivation
- Cung cấp một tiện ích Chrome để thu thập thông tin sản phẩm từ các trang `greetbuy.com/goods/*` và lưu dữ liệu đó cục bộ trên trình duyệt.
- Cho phép người dùng nhanh chóng lưu sản phẩm hiện tại từ trang sản phẩm, xem danh sách đã lưu trong popup và mở trang chi tiết trong extension.
- Giảm phụ thuộc vào cấu trúc HTML cố định bằng cách thu thập dữ liệu qua nhiều selector và fallback (meta, JSON-LD, bảng thông số, ảnh, snapshot HTML).

### Description
- Thêm `manifest.json` (Manifest V3) với quyền `storage`, `activeTab`, `scripting`, `tabs` và `host_permissions` cho `https://www.greetbuy.com/*` và đăng ký `content-script.js` cho đường dẫn sản phẩm.
- Thêm `content-script.js` để thu thập `title`, `description`, `priceText`/`priceCandidates`, `images`/`mainImage`, `specs`, `jsonLd` và `htmlSnapshot`, trả về dữ liệu qua message `GB_CAPTURE_PRODUCT`.
- Thêm popup UI (`popup.html`, `popup.css`, `popup.js`) để người dùng bấm `Lưu sản phẩm hiện tại`, ghi nhận dữ liệu vào `chrome.storage.local` và hiển thị danh sách sản phẩm đã lưu cùng các hành động mở chi tiết hoặc mở nguồn.
- Thêm trang chi tiết (`detail.html`, `detail.css`, `detail.js`) để xem thông số sản phẩm đã lưu và mở lại URL gốc, cùng `background.js` nhỏ để log khi cài đặt và `README.md` hướng dẫn cài đặt/sử dụng.

### Testing
- Parsed `manifest.json` with `node -e "JSON.parse(require('fs').readFileSync('manifest.json','utf8'))"` which succeeded.
- Performed syntax checks with `node --check` on `popup.js`, `content-script.js`, `detail.js`, and `background.js`, and all checks passed.
- Attempted a Playwright screenshot run to preview the popup UI, but the run failed due to `file:///` path resolution in the environment and did not produce a screenshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4fd98917c832f8d9155cf483ee2a8)